### PR TITLE
Fixed Display Item drop bug when placing block above barrel

### DIFF
--- a/src/me/john000708/barrels/listeners/DisplayListener.java
+++ b/src/me/john000708/barrels/listeners/DisplayListener.java
@@ -1,15 +1,20 @@
 package me.john000708.barrels.listeners;
 
 import me.john000708.barrels.Barrels;
+import me.john000708.barrels.DisplayItem;
+
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.inventory.InventoryPickupItemEvent;
 import org.bukkit.event.player.PlayerPickupItemEvent;
 
 /**
  * Created by John on 10.05.2016.
  */
+@SuppressWarnings("deprecation")
 public class DisplayListener implements Listener {
 	
     public DisplayListener() {
@@ -18,7 +23,7 @@ public class DisplayListener implements Listener {
 
     @EventHandler
     public void onPickpup(PlayerPickupItemEvent e) {
-        if (!e.getItem().hasMetadata("no_pickup") && e.getItem().getItemStack().hasItemMeta() && e.getItem().getItemStack().getItemMeta().hasDisplayName() && e.getItem().getItemStack().getItemMeta().getDisplayName().startsWith("§6§lB4R3L - §eITEM")) {
+        if (!e.getItem().hasMetadata("no_pickup") && e.getItem().getItemStack().hasItemMeta() && e.getItem().getItemStack().getItemMeta().hasDisplayName() && e.getItem().getItemStack().getItemMeta().getDisplayName().startsWith("Â§6Â§lB4R3L - Â§eITEM")) {
         	e.setCancelled(true);
         	e.getItem().remove();
         }
@@ -26,9 +31,15 @@ public class DisplayListener implements Listener {
 
     @EventHandler
     public void onInventoryPickup(InventoryPickupItemEvent e) {
-        if (!e.getItem().hasMetadata("no_pickup") && e.getItem().getItemStack().hasItemMeta() && e.getItem().getItemStack().getItemMeta().hasDisplayName() && e.getItem().getItemStack().getItemMeta().getDisplayName().startsWith("§6§lB4R3L - §eITEM")) {
+        if (!e.getItem().hasMetadata("no_pickup") && e.getItem().getItemStack().hasItemMeta() && e.getItem().getItemStack().getItemMeta().hasDisplayName() && e.getItem().getItemStack().getItemMeta().getDisplayName().startsWith("Â§6Â§lB4R3L - Â§eITEM")) {
         	e.setCancelled(true);
         	e.getItem().remove();
         }
+    }
+    
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void on(BlockPlaceEvent e) {
+        if (!e.isCancelled()) { // Check if the block was actually placed
+        	DisplayItem.removeDisplayItem(e.getBlock().getRelative(0, -1, 0));        }
     }
 }

--- a/src/me/john000708/barrels/listeners/WorldListener.java
+++ b/src/me/john000708/barrels/listeners/WorldListener.java
@@ -11,6 +11,7 @@ import org.bukkit.event.block.BlockPlaceEvent;
 /**
  * Created by John on 14.05.2016.
  */
+@SuppressWarnings("unused")
 public class WorldListener implements Listener {
 	
     public WorldListener() {


### PR DESCRIPTION
I noticed that when placing a block above the barrel, it would push the display item onto the ground, this fixes it.