### PR TITLE
Fixed barrels

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>com.github.TheBusyBiscuit</groupId>
             <artifactId>CS-CoreLib</artifactId>
-            <version>6e17183656</version>
+            <version>1.7</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>com.github.TheBusyBiscuit</groupId>
             <artifactId>Slimefun4</artifactId>
-            <version>RC-14</version>
+            <version>RC-16</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/src/main/java/me/john000708/barrels/Barrels.java
+++ b/src/main/java/me/john000708/barrels/Barrels.java
@@ -39,10 +39,9 @@ public class Barrels extends JavaPlugin implements SlimefunAddon {
         Config config = new Config(this);
 
         // Setting up the Auto-Updater
-        Updater updater = new GitHubBuildsUpdater(this, getFile(), "John000708/Barrels/master");
 
-        if (config.getBoolean("options.auto-update")) {
-            updater.start();
+        if (getConfig().getBoolean("options.auto-update") && getDescription().getVersion().startsWith("DEV - ")) {
+            new GitHubBuildsUpdater(this, getFile(), "John000708/Barrels/master").start();
         }
 
         new DisplayListener(this);

--- a/src/main/java/me/john000708/barrels/block/Barrel.java
+++ b/src/main/java/me/john000708/barrels/block/Barrel.java
@@ -1,13 +1,16 @@
 package me.john000708.barrels.block;
 
+import io.github.thebusybiscuit.slimefun4.core.handlers.BlockPlaceHandler;
+import me.mrCookieSlime.Slimefun.Objects.handlers.ItemHandler;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
-import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import me.john000708.barrels.Barrels;
 import me.john000708.barrels.DisplayItem;
 import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
@@ -35,6 +38,20 @@ public abstract class Barrel extends SimpleSlimefunItem<BlockTicker> {
 
         new BarrelsMenuPreset(this);
         registerBlockHandler(getID(), new BarrelsBlockHandler(this));
+
+        addItemHandler(onPlace());
+    }
+
+    private ItemHandler onPlace() {
+        return new BlockPlaceHandler(false) {
+            @Override
+            public void onPlayerPlace(BlockPlaceEvent e) {
+                Block b = e.getBlock();
+                Player p = e.getPlayer();
+                BlockStorage.addBlockInfo(b, "owner", p.getUniqueId().toString());
+                BlockStorage.addBlockInfo(b, "whitelist", " ");
+            }
+        };
     }
 
     public abstract String getInventoryTitle();
@@ -128,7 +145,7 @@ public abstract class Barrel extends SimpleSlimefunItem<BlockTicker> {
             if (inventory.getItemInSlot(slot) != null) {
                 ItemStack input = inventory.getItemInSlot(slot);
 
-                if (SlimefunUtils.isItemSimilar(input, inventory.getItemInSlot(22), true, false)) {
+                if (input.getItemMeta().equals(inventory.getItemInSlot(22).getItemMeta())) {
                     if (BlockStorage.getLocationInfo(b.getLocation(), "storedItems") == null) {
                         BlockStorage.addBlockInfo(b, "storedItems", "1");
                     }
@@ -167,7 +184,8 @@ public abstract class Barrel extends SimpleSlimefunItem<BlockTicker> {
         ItemStack output = inventory.getItemInSlot(22).clone();
 
         if (inventory.getItemInSlot(getOutputSlots()[0]) != null && inventory.getItemInSlot(getOutputSlots()[0]).getType() != Material.AIR) {
-            if (!SlimefunUtils.isItemSimilar(inventory.getItemInSlot(getOutputSlots()[0]), output, true, false)) {
+            // This is used to prevent items with different enchants and potion types from merging
+            if (!inventory.getItemInSlot(getOutputSlots()[0]).getItemMeta().equals(output.getItemMeta())) {
                 return;
             }
 

--- a/src/main/java/me/john000708/barrels/block/BarrelsBlockHandler.java
+++ b/src/main/java/me/john000708/barrels/block/BarrelsBlockHandler.java
@@ -21,13 +21,6 @@ class BarrelsBlockHandler implements SlimefunBlockHandler {
     }
 
     @Override
-    public void onPlace(Player player, Block block, SlimefunItem slimefunItem) {
-        BlockStorage.addBlockInfo(block, "owner", player.getUniqueId().toString());
-        BlockStorage.addBlockInfo(block, "whitelist", " ");
-        // DONT DO ANYTHING - Inventory is not yet loaded
-    }
-
-    @Override
     public boolean onBreak(Player player, Block b, SlimefunItem slimefunItem, UnregisterReason unregisterReason) {
         if (unregisterReason.equals(UnregisterReason.EXPLODE)) {
             if (BlockStorage.getLocationInfo(b.getLocation(), "explosion") != null) {

--- a/src/main/java/me/john000708/barrels/block/BarrelsBlockHandler.java
+++ b/src/main/java/me/john000708/barrels/block/BarrelsBlockHandler.java
@@ -1,5 +1,8 @@
 package me.john000708.barrels.block;
 
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -15,6 +18,7 @@ import me.mrCookieSlime.Slimefun.cscorelib2.item.CustomItem;
 class BarrelsBlockHandler implements SlimefunBlockHandler {
 
     private final Barrel barrel;
+    boolean explosiveBreak;
 
     public BarrelsBlockHandler(Barrel barrel) {
         this.barrel = barrel;
@@ -32,6 +36,10 @@ class BarrelsBlockHandler implements SlimefunBlockHandler {
             // Only the Owner may break this Barrel
             if (!BlockStorage.getLocationInfo(b.getLocation(), "owner").equals(player.getUniqueId().toString())) {
                 return false;
+            }
+
+            if (SlimefunUtils.isItemSimilar(player.getInventory().getItemInMainHand(), SlimefunItems.EXPLOSIVE_PICKAXE, false)) {
+                explosiveBreak = true;
             }
         }
 
@@ -87,6 +95,12 @@ class BarrelsBlockHandler implements SlimefunBlockHandler {
             }
 
             b.getWorld().dropItem(b.getLocation(), new CustomItem(item, amount));
+        }
+
+        if (explosiveBreak) {
+            b.getWorld().dropItem(b.getLocation(), BlockStorage.check(b).getItem());
+            BlockStorage.clearBlockInfo(b);
+            b.setType(Material.AIR);
         }
 
         return true;


### PR DESCRIPTION
## Changes
- Updated POM to use latest CSCoreLib (This was causing a problem due to a deprecated method)
- Updated Slimefun on POM
- Moved the block place handler inside the Barrels class because it no longer works as a SlimefunBlockHandler
- Fixed "dupe" with items by comparing the items to exact metadata, which includes slimefun id, potion types, and enchantments so that plain items can not be merged into enchanted items
- Fixed a problem with the updater what tried to update test builds